### PR TITLE
Folder restructure

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,9 @@
     "ecmaVersion": 12,
     "sourceType": "module"
   },
+  "settings": {
+    "import/resolver": "webpack"
+  },
   "rules": {
     "no-console": "off",
     "no-undef": "off"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "css-loader": "^6.4.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.3.0",
+        "eslint-import-resolver-webpack": "^0.13.1",
         "eslint-plugin-import": "^2.25.1",
         "mini-css-extract-plugin": "^2.4.2",
         "node-sass": "^6.0.1",
@@ -605,6 +606,12 @@
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "node_modules/array-find": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-find/-/array-find-1.0.0.tgz",
+      "integrity": "sha1-bI4obRHtdoMn+OYuzuhzU8o+eLg=",
+      "dev": true
     },
     "node_modules/array-includes": {
       "version": "3.1.4",
@@ -1515,6 +1522,82 @@
         "ms": "^2.1.1"
       }
     },
+    "node_modules/eslint-import-resolver-webpack": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-webpack/-/eslint-import-resolver-webpack-0.13.1.tgz",
+      "integrity": "sha512-O/8mG6AHmaKYSMb4lWxiXPpaARxOJ4rMQEHJ8vTgjS1MXooJA3KPgBPPAdOPoV17v5ML5120qod5FBLM+DtgEw==",
+      "dev": true,
+      "dependencies": {
+        "array-find": "^1.0.0",
+        "debug": "^3.2.7",
+        "enhanced-resolve": "^0.9.1",
+        "find-root": "^1.1.0",
+        "has": "^1.0.3",
+        "interpret": "^1.4.0",
+        "is-core-module": "^2.4.0",
+        "is-regex": "^1.1.3",
+        "lodash": "^4.17.21",
+        "resolve": "^1.20.0",
+        "semver": "^5.7.1"
+      },
+      "engines": {
+        "node": "^16 || ^15 || ^14 || ^13 || ^12 || ^11 || ^10 || ^9 || ^8 || ^7 || ^6"
+      },
+      "peerDependencies": {
+        "eslint-plugin-import": ">=1.4.0",
+        "webpack": ">=1.11.0"
+      }
+    },
+    "node_modules/eslint-import-resolver-webpack/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-webpack/node_modules/enhanced-resolve": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
+      "integrity": "sha1-TW5omzcl+GCQknzMhs2fFjW4ni4=",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "memory-fs": "^0.2.0",
+        "tapable": "^0.1.8"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/eslint-import-resolver-webpack/node_modules/interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/eslint-import-resolver-webpack/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/eslint-import-resolver-webpack/node_modules/tapable": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
+      "integrity": "sha1-KcNXB8K3DlDQdIK10gLo7URtr9Q=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/eslint-module-utils": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.1.tgz",
@@ -1901,6 +1984,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "dev": true
     },
     "node_modules/find-up": {
       "version": "2.1.0",
@@ -3080,6 +3169,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/memory-fs": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz",
+      "integrity": "sha1-8rslNovBIeORwlIN6Slpyu4KApA=",
+      "dev": true
     },
     "node_modules/meow": {
       "version": "9.0.0",
@@ -6043,6 +6138,12 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "array-find": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-find/-/array-find-1.0.0.tgz",
+      "integrity": "sha1-bI4obRHtdoMn+OYuzuhzU8o+eLg=",
+      "dev": true
+    },
     "array-includes": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
@@ -6753,6 +6854,65 @@
         }
       }
     },
+    "eslint-import-resolver-webpack": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-webpack/-/eslint-import-resolver-webpack-0.13.1.tgz",
+      "integrity": "sha512-O/8mG6AHmaKYSMb4lWxiXPpaARxOJ4rMQEHJ8vTgjS1MXooJA3KPgBPPAdOPoV17v5ML5120qod5FBLM+DtgEw==",
+      "dev": true,
+      "requires": {
+        "array-find": "^1.0.0",
+        "debug": "^3.2.7",
+        "enhanced-resolve": "^0.9.1",
+        "find-root": "^1.1.0",
+        "has": "^1.0.3",
+        "interpret": "^1.4.0",
+        "is-core-module": "^2.4.0",
+        "is-regex": "^1.1.3",
+        "lodash": "^4.17.21",
+        "resolve": "^1.20.0",
+        "semver": "^5.7.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "enhanced-resolve": {
+          "version": "0.9.1",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
+          "integrity": "sha1-TW5omzcl+GCQknzMhs2fFjW4ni4=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "memory-fs": "^0.2.0",
+            "tapable": "^0.1.8"
+          }
+        },
+        "interpret": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+          "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
+        "tapable": {
+          "version": "0.1.10",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
+          "integrity": "sha1-KcNXB8K3DlDQdIK10gLo7URtr9Q=",
+          "dev": true
+        }
+      }
+    },
     "eslint-module-utils": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.1.tgz",
@@ -7052,6 +7212,12 @@
       "requires": {
         "to-regex-range": "^5.0.1"
       }
+    },
+    "find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "dev": true
     },
     "find-up": {
       "version": "2.1.0",
@@ -7929,6 +8095,12 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
       "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+      "dev": true
+    },
+    "memory-fs": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz",
+      "integrity": "sha1-8rslNovBIeORwlIN6Slpyu4KApA=",
       "dev": true
     },
     "meow": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "css-loader": "^6.4.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
+    "eslint-import-resolver-webpack": "^0.13.1",
     "eslint-plugin-import": "^2.25.1",
     "mini-css-extract-plugin": "^2.4.2",
     "node-sass": "^6.0.1",

--- a/src/module/actor/base-actor-sheet.js
+++ b/src/module/actor/base-actor-sheet.js
@@ -1,4 +1,4 @@
-export class TorchbearerActorSheet extends ActorSheet {
+export class TorchbearerBaseActorSheet extends ActorSheet {
   static get defaultOptions() {
     return mergeObject(super.defaultOptions, {
       classes: ["torchbearer", "sheet", "actor"],

--- a/src/module/actor/base-actor.js
+++ b/src/module/actor/base-actor.js
@@ -1,9 +1,9 @@
-import { arrangeInventory } from "../inventory/inventory.js";
-import { arrangeSpells } from "../inventory/inventory.js";
+import { arrangeInventory } from "@inventory/inventory.js";
+import { arrangeSpells } from "@inventory/inventory.js";
 
 const GRIND_CONDITION_SEQUENCE = ["hungryandthirsty", "exhausted", "angry", "sick", "injured", "afraid", "dead"];
 
-export class TorchbearerActor extends Actor {
+export class TorchbearerBaseActor extends Actor {
   /**
    * Augment the basic actor data with additional dynamic data.
    */

--- a/src/module/actor/character/index.js
+++ b/src/module/actor/character/index.js
@@ -1,0 +1,1 @@
+export { TorchbearerCharacterSheet } from './sheet';

--- a/src/module/actor/character/sheet.js
+++ b/src/module/actor/character/sheet.js
@@ -1,8 +1,8 @@
-import { TorchbearerActorSheet } from "./actor-sheet.js";
-import { alternateContainerType, canFit } from "../inventory/inventory.js";
-import { PlayerRoll } from "../rolls/playerRoll.js";
+import { TorchbearerBaseActorSheet } from "../base-actor-sheet";
+import { alternateContainerType, canFit } from "@inventory/inventory";
+import { PlayerRoll } from "@rolls/playerRoll";
 
-export class TorchbearerCharacterSheet extends TorchbearerActorSheet {
+export class TorchbearerCharacterSheet extends TorchbearerBaseActorSheet {
   /** @override */
   static get defaultOptions() {
     return mergeObject(super.defaultOptions, {

--- a/src/module/actor/character/sheet.js
+++ b/src/module/actor/character/sheet.js
@@ -351,7 +351,7 @@ export class TorchbearerCharacterSheet extends TorchbearerBaseActorSheet {
   }
 
   async handleDropItem(item) {
-    // item.document means we got an ItemData rather than a TorchbearerItem
+    // item.document means we got an ItemData rather than a TorchbearerBaseItem
     const tbItem = item.document ? item.document : item;
 
     if (tbItem.type === "Spell") {

--- a/src/module/actor/index.js
+++ b/src/module/actor/index.js
@@ -1,0 +1,4 @@
+export { TorchbearerCharacterSheet } from "./character";
+export { TorchbearerMonsterSheet } from "./monster";
+export { TorchbearerNPCSheet } from "./npc";
+export { TorchbearerBaseActor } from "./base-actor";

--- a/src/module/actor/monster/index.js
+++ b/src/module/actor/monster/index.js
@@ -1,0 +1,1 @@
+export { TorchbearerMonsterSheet } from "./sheet";

--- a/src/module/actor/monster/sheet.js
+++ b/src/module/actor/monster/sheet.js
@@ -1,6 +1,6 @@
-import { TorchbearerActorSheet } from "./actor-sheet.js";
+import { TorchbearerBaseActorSheet } from "../base-actor-sheet";
 
-export class TorchbearerMonsterSheet extends TorchbearerActorSheet {
+export class TorchbearerMonsterSheet extends TorchbearerBaseActorSheet {
   /** @override */
   static get defaultOptions() {
     return mergeObject(super.defaultOptions, {

--- a/src/module/actor/npc/index.js
+++ b/src/module/actor/npc/index.js
@@ -1,0 +1,1 @@
+export { TorchbearerNPCSheet } from "./sheet";

--- a/src/module/actor/npc/sheet.js
+++ b/src/module/actor/npc/sheet.js
@@ -1,4 +1,4 @@
-import { TorchbearerCharacterSheet } from "./character-sheet.js";
+import { TorchbearerCharacterSheet } from "../character";
 
 export class TorchbearerNPCSheet extends TorchbearerCharacterSheet {
   /** @override */

--- a/src/module/inventory/inventory.js
+++ b/src/module/inventory/inventory.js
@@ -23,7 +23,7 @@ let bundleableItem = function (tbItem, container, itemOwnInventory) {
 
 export function arrangeInventory(tbItemsMap, overburdened) {
   //For the most part just arrange item data not
-  // TorchbearerItem objects...is this necessary?
+  // TorchbearerBaseItem objects...is this necessary?
   if (!tbItemsMap) return;
   const tbItems = [];
   for (const tbItem of tbItemsMap) {

--- a/src/module/item/base-item.js
+++ b/src/module/item/base-item.js
@@ -4,7 +4,7 @@ import { itemExtensions } from "./itemExtensions.js";
  * Extend the basic Item with some very simple modifications.
  * @extends {Item}
  */
-export class TorchbearerItem extends Item {
+export class TorchbearerBaseItem extends Item {
   /**
    * Augment the basic Item data model with additional dynamic data.
    */

--- a/src/module/item/index.js
+++ b/src/module/item/index.js
@@ -1,0 +1,3 @@
+export { TorchbearerBaseItem } from "./base-item";
+export { TorchbearerItemSheet } from "./item";
+export { TorchbearerSpellSheet } from "./spell";

--- a/src/module/item/item/index.js
+++ b/src/module/item/item/index.js
@@ -1,0 +1,1 @@
+export { TorchbearerItemSheet } from './sheet';

--- a/src/module/item/item/sheet.js
+++ b/src/module/item/item/sheet.js
@@ -1,4 +1,4 @@
-import { TorchbearerBaseItemSheet } from "./base-item-sheet.js";
+import { TorchbearerBaseItemSheet } from "../base-item-sheet";
 
 export class TorchbearerItemSheet extends TorchbearerBaseItemSheet {
   /** @override */

--- a/src/module/item/spell/index.js
+++ b/src/module/item/spell/index.js
@@ -1,0 +1,1 @@
+export { TorchbearerSpellSheet } from "./sheet";

--- a/src/module/item/spell/sheet.js
+++ b/src/module/item/spell/sheet.js
@@ -1,4 +1,4 @@
-import { TorchbearerBaseItemSheet } from "./base-item-sheet.js";
+import { TorchbearerBaseItemSheet } from "../base-item-sheet";
 
 export class TorchbearerSpellSheet extends TorchbearerBaseItemSheet {
   /** @override */

--- a/src/torchbearer.js
+++ b/src/torchbearer.js
@@ -1,8 +1,5 @@
 // Import Modules
-import { TorchbearerActor } from "./module/actor/actor.js";
-import { TorchbearerCharacterSheet } from "./module/actor/character-sheet.js";
-import { TorchbearerMonsterSheet } from "./module/actor/monster-sheet.js";
-import { TorchbearerNPCSheet } from "./module/actor/npc-sheet.js";
+import { TorchbearerBaseActor, TorchbearerCharacterSheet, TorchbearerMonsterSheet, TorchbearerNPCSheet } from "@actor";
 import { TorchbearerItem } from "./module/item/item.js";
 import { TorchbearerItemSheet } from "./module/item/item-sheet.js";
 import { TorchbearerSpellSheet } from "./module/item/spell-sheet.js";
@@ -17,7 +14,7 @@ import "./styles/torchbearer.scss";
 
 Hooks.once("init", async function () {
   game.torchbearer = {
-    TorchbearerActor,
+    TorchbearerBaseActor,
     TorchbearerItem,
   };
 
@@ -124,7 +121,7 @@ Hooks.once("init", async function () {
   });
 
   // Define custom Entity classes
-  CONFIG.Actor.documentClass = TorchbearerActor;
+  CONFIG.Actor.documentClass = TorchbearerBaseActor;
   CONFIG.Item.documentClass = TorchbearerItem;
 
   // Register sheet application classes

--- a/src/torchbearer.js
+++ b/src/torchbearer.js
@@ -11,11 +11,6 @@ import { Capitalize } from "./module/misc.js";
 import "./styles/torchbearer.scss";
 
 Hooks.once("init", async function () {
-  game.torchbearer = {
-    TorchbearerBaseActor,
-    TorchbearerBaseItem,
-  };
-
   game.gmIsActive = () => {
     for (let i = 0; i < game.users.entities.length; i++) {
       const user = game.users.entities[i];

--- a/src/torchbearer.js
+++ b/src/torchbearer.js
@@ -1,8 +1,6 @@
 // Import Modules
 import { TorchbearerBaseActor, TorchbearerCharacterSheet, TorchbearerMonsterSheet, TorchbearerNPCSheet } from "@actor";
-import { TorchbearerItem } from "./module/item/item.js";
-import { TorchbearerItemSheet } from "./module/item/item-sheet.js";
-import { TorchbearerSpellSheet } from "./module/item/spell-sheet.js";
+import { TorchbearerBaseItem, TorchbearerItemSheet, TorchbearerSpellSheet } from "@item";
 import { ConflictSheet } from "./module/conflict/conflict.js";
 import { GrindSheet } from "./module/grind.js";
 
@@ -15,7 +13,7 @@ import "./styles/torchbearer.scss";
 Hooks.once("init", async function () {
   game.torchbearer = {
     TorchbearerBaseActor,
-    TorchbearerItem,
+    TorchbearerBaseItem,
   };
 
   game.gmIsActive = () => {
@@ -122,7 +120,7 @@ Hooks.once("init", async function () {
 
   // Define custom Entity classes
   CONFIG.Actor.documentClass = TorchbearerBaseActor;
-  CONFIG.Item.documentClass = TorchbearerItem;
+  CONFIG.Item.documentClass = TorchbearerBaseItem;
 
   // Register sheet application classes
   Actors.unregisterSheet("core", ActorSheet);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -61,6 +61,16 @@ module.exports = {
   devtool: isDevelopment ? "inline-source-map" : undefined,
   bail: !isDevelopment,
   watch: isDevelopment,
+  resolve: {
+    alias: {
+      "@actor": path.resolve(__dirname, "src/module/actor"),
+      "@conflict": path.resolve(__dirname, "src/module/conflict"),
+      "@inventory": path.resolve(__dirname, "src/module/inventory"),
+      "@item": path.resolve(__dirname, "src/module/item"),
+      "@rolls": path.resolve(__dirname, "src/module/rolls"),
+    },
+    extensions: [".js"],
+  },
   output: {
     clean: true,
     path: outDir,


### PR DESCRIPTION
- Allows webpack and eslint to understand aliases so that we don't have to count all the `../../..` to get from one folder to another.
- Moves all the different character and item sheet classes into their own folders. This is partly just for cleanliness, but it will help keep things clean when we add e.g. different actor classes as well.