### PR TITLE
Support all five spell circles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Patch Notes
 
+## Version 1.2.0
+
+### Enhancements
+
+- The character spell list now supports five circles (First through Fifth).
+
 ## Version 1.1.0
 
 Support FoundryVTT 0.8.9.

--- a/src/module/actor/character/actor.js
+++ b/src/module/actor/character/actor.js
@@ -1,5 +1,6 @@
 import { TorchbearerBaseActor } from "../base";
-import { arrangeInventory, arrangeSpells } from "@inventory/inventory";
+import { TorchbearerSpell } from "@item";
+import { arrangeInventory } from "@inventory/inventory";
 
 const GRIND_CONDITION_SEQUENCE = ["hungryandthirsty", "exhausted", "angry", "sick", "injured", "afraid", "dead"];
 
@@ -12,7 +13,7 @@ export class TorchbearerCharacterActor extends TorchbearerBaseActor {
     // Make a new Object that holds computed data and keeps it separate from anything else
     data.computed = {};
 
-    data.computed.spells = arrangeSpells(this.items);
+    data.computed.spellData = TorchbearerSpell.dataByCircle(this.items);
 
     data.computed.inventory = arrangeInventory(this.items, data.overburdened);
     //The first time this is executed, Actors don't have their items yet, so there is

--- a/src/module/actor/character/sheet.js
+++ b/src/module/actor/character/sheet.js
@@ -247,10 +247,7 @@ export class TorchbearerCharacterSheet extends TorchbearerBaseActorSheet {
     html.find(".spell-toggle").click((ev) => {
       const checkbox = ev.currentTarget;
 
-      const updates = {};
-      updates[`data.${checkbox.dataset.checkboxType}`] = checkbox.checked;
-
-      this.actor.items.get(spellId(ev)).update(updates);
+      this.actor.items.get(spellId(ev)).update({ [`data.${checkbox.dataset.checkboxType}`]: checkbox.checked });
     });
   }
 

--- a/src/module/actor/character/sheet.js
+++ b/src/module/actor/character/sheet.js
@@ -1,4 +1,5 @@
 import { TorchbearerBaseActorSheet } from "../base-sheet";
+import { TorchbearerItem } from "@item";
 import { alternateContainerType, canFit } from "@inventory/inventory";
 import { PlayerRoll } from "@rolls/playerRoll";
 
@@ -336,9 +337,7 @@ export class TorchbearerCharacterSheet extends TorchbearerBaseActorSheet {
     // item.document means we got an ItemData rather than a TorchbearerBaseItem
     const tbItem = item.document ? item.document : item;
 
-    if (tbItem.type === "Spell") {
-      console.log("Yer a wizard, Harry");
-    } else {
+    if (tbItem instanceof TorchbearerItem) {
       if (tbItem.data) {
         await tbItem.syncEquipVariables();
 

--- a/src/module/actor/character/sheet.js
+++ b/src/module/actor/character/sheet.js
@@ -248,7 +248,7 @@ export class TorchbearerCharacterSheet extends TorchbearerBaseActorSheet {
       const checkbox = ev.currentTarget;
 
       const updates = {};
-      updates[`data.${checkbox.title}`] = checkbox.checked;
+      updates[`data.${checkbox.dataset.checkboxType}`] = checkbox.checked;
 
       this.actor.items.get(spellId(ev)).update(updates);
     });

--- a/src/module/actor/character/sheet.js
+++ b/src/module/actor/character/sheet.js
@@ -97,6 +97,8 @@ export class TorchbearerCharacterSheet extends TorchbearerBaseActorSheet {
     // Add Inventory Item
     //html.find('.item-create').click(this._onItemCreate.bind(this));
 
+    this.activateSpellListeners(html);
+
     // Update Inventory Item
     html.find(".item-name.clickable").click((ev) => {
       console.log(ev.currentTarget);
@@ -104,13 +106,6 @@ export class TorchbearerCharacterSheet extends TorchbearerBaseActorSheet {
       const item = this.actor.items.get(li.data("itemId"));
       // const equip = item.data.data.equip;
       item.sheet.render(true);
-    });
-
-    // Update Inventory Item
-    html.find(".spell-name.clickable").click((ev) => {
-      const spell = this.actor.items.get(ev.currentTarget.title);
-      console.log(spell);
-      spell.sheet.render(true);
     });
 
     // Delete Inventory Item
@@ -121,40 +116,6 @@ export class TorchbearerCharacterSheet extends TorchbearerBaseActorSheet {
         // Get the equipment slot of the item being deleted
         li.slideUp(200, () => this.render(false));
       });
-    });
-
-    // Delete Spell Item
-    html.find(".spell-delete").click((ev) => {
-      document.getElementById(ev.currentTarget.name).remove();
-      this.actor.removeItemFromInventory(ev.currentTarget.name);
-    });
-
-    // Update spell data
-    html.find(".spell-toggle").click((ev) => {
-      // ev.preventDefault();
-      const spell = this.actor.items.get(ev.currentTarget.id);
-      let checkState = ev.currentTarget.checked;
-      console.log(spell);
-      switch (ev.currentTarget.title) {
-        case "cast":
-          spell.update({ "data.cast": checkState });
-          break;
-        case "library":
-          spell.update({ "data.library": checkState });
-          break;
-        case "spellbook":
-          spell.update({ "data.spellbook": checkState });
-          break;
-        case "memorized":
-          spell.update({ "data.memorized": checkState });
-          break;
-        case "scroll":
-          spell.update({ "data.scroll": checkState });
-          break;
-        case "supplies":
-          spell.update({ "data.supplies": checkState });
-          break;
-      }
     });
 
     // Drop Inventory Item
@@ -269,6 +230,27 @@ export class TorchbearerCharacterSheet extends TorchbearerBaseActorSheet {
     //     });
     //   });
     // });
+  }
+
+  activateSpellListeners(html) {
+    const spellId = (ev) => $(ev.currentTarget).parents(".spell-row").data("spellId");
+
+    html.find(".spell-name.clickable").click((ev) => {
+      this.actor.items.get(spellId(ev)).sheet.render(true);
+    });
+
+    html.find(".spell-delete").click(async (ev) => {
+      await this.actor.deleteEmbeddedDocuments("Item", [spellId(ev)]);
+    });
+
+    html.find(".spell-toggle").click((ev) => {
+      const checkbox = ev.currentTarget;
+
+      const updates = {};
+      updates[`data.${checkbox.title}`] = checkbox.checked;
+
+      this.actor.items.get(spellId(ev)).update(updates);
+    });
   }
 
   /* -------------------------------------------- */

--- a/src/module/inventory/inventory.js
+++ b/src/module/inventory/inventory.js
@@ -325,48 +325,6 @@ function capacityConsumedIn(container) {
   return consumed;
 }
 
-export function arrangeSpells(tbItemsMap) {
-  if (!tbItemsMap) return;
-
-  let spellInventory = {
-    first: [],
-    second: [],
-    third: [],
-    fourth: [],
-    fifth: [],
-  };
-
-  const tbSpells = [];
-  for (const tbSpell of tbItemsMap) {
-    if (tbSpell.data.type === "Spell") {
-      tbSpells.push(tbSpell.data);
-      // Pushes the item data instead of the item itself to prevent breaking tokens
-      // with recursive searches.
-    }
-  }
-
-  tbSpells.forEach((element) => {
-    switch (element.data.circle) {
-      case "First":
-        spellInventory.first.push(element);
-        break;
-      case "Second":
-        spellInventory.second.push(element);
-        break;
-      case "Third":
-        spellInventory.third.push(element);
-        break;
-      case "Fourth":
-        spellInventory.fourth.push(element);
-        break;
-      case "Fifth":
-        spellInventory.fifth.push(element);
-        break;
-    }
-  });
-  return spellInventory;
-}
-
 Handlebars.registerHelper("renderInventory", function (capacity, actorId, containerId, placeholder, sheet) {
   let { multiSlot, droppable } = renderOptions(containerId);
   let html = "";

--- a/src/module/item/spell/item.js
+++ b/src/module/item/spell/item.js
@@ -1,3 +1,20 @@
 import { TorchbearerBaseItem } from "../base";
+import _ from "lodash";
 
-export class TorchbearerSpell extends TorchbearerBaseItem {}
+const CIRCLES = ["First", "Second", "Third", "Fourth", "Fifth"];
+
+export class TorchbearerSpell extends TorchbearerBaseItem {
+  /**
+   * Returns a map from a circle name to all spells in that circle
+   */
+  static dataByCircle(items) {
+    const spells = items.filter(
+      (item) => item instanceof TorchbearerSpell && _.includes(CIRCLES, item.data.data.circle)
+    );
+
+    return _.groupBy(
+      spells.map((spell) => spell.data),
+      (spellData) => spellData.data.circle
+    );
+  }
+}

--- a/src/scripts/templates.js
+++ b/src/scripts/templates.js
@@ -1,0 +1,5 @@
+export async function preloadHandlebarsTemplates() {
+  const paths = ["systems/torchbearer/templates/parts/spell-list.html.hbs"];
+
+  return loadTemplates(paths);
+}

--- a/src/styles/components/_spells.scss
+++ b/src/styles/components/_spells.scss
@@ -1,0 +1,22 @@
+.spells {
+  font-family: Souvenir-Medium;
+
+  th {
+    font-family: Souvenir-Demi;
+    text-align: center;
+  }
+
+  .spell-header {
+    text-align: center;
+    background-color: rgba(0, 0, 0, 0.05);
+    border-bottom: 1px solid gray;
+  }
+
+  .spell-name {
+    margin-bottom: 0px;
+  }
+
+  .control {
+    text-align: center;
+  }
+}

--- a/src/styles/torchbearer.scss
+++ b/src/styles/torchbearer.scss
@@ -16,6 +16,7 @@
   @import "components/tabs";
   @import "components/actors";
   @import "components/items";
+  @import "components/spells";
 }
 
 /* TODO: Everything below this point was salvaged from torchbearer.css without properly being written in SCSS.

--- a/src/torchbearer.js
+++ b/src/torchbearer.js
@@ -5,6 +5,7 @@ import { ConflictSheet } from "./module/conflict/conflict.js";
 import { GrindSheet } from "./module/grind.js";
 
 import { TORCHBEARER } from "@scripts/config";
+import { preloadHandlebarsTemplates } from "@scripts/templates";
 
 // Import Helpers
 import * as chat from "./module/chat.js";
@@ -179,4 +180,6 @@ Hooks.once("init", async function () {
   Handlebars.registerHelper("json", function (context) {
     return JSON.stringify(context);
   });
+
+  preloadHandlebarsTemplates();
 });

--- a/static/templates/actor/character-sheet.html.hbs
+++ b/static/templates/actor/character-sheet.html.hbs
@@ -1320,96 +1320,21 @@
     {{! Magic Tab }}
     <div class="tab" data-group="primary" data-tab="magic">
 
-      <table class="tbtable">
-        <thead class="theader" style="font-family: Souvenir-Demi;">
-          <th style="text-align: center;">Cast?</th>
-          <th style="text-align: center">Spell</th>
-          <th style="text-align: center;">Library</th>
-          <th style="text-align: center;">Book</th>
-          <th style="text-align: center;">Mem.</th>
-          <th style="text-align: center;">Scroll</th>
-          <th style="text-align: center;">Supplies</th>
+      <table class="tbtable spells">
+        <thead class="theader">
+          <th>Cast?</th>
+          <th>Spell</th>
+          <th>Library</th>
+          <th>Book</th>
+          <th>Mem.</th>
+          <th>Scroll</th>
+          <th>Supplies</th>
           <th></th>
         </thead>
 
-        <tbody style="font-family: Souvenir-Medium;">
-          <!-- First Circle Spells -->
-          <tr>
-            <td
-              colspan="8"
-              style="text-align: center; background-color: rgba(0, 0, 0, 0.05); border-bottom: 1px solid gray;"
-            >~ First Circle ~</td>
-          </tr>
-          {{#each data.computed.spells.first as |spell|}}
-            <tr id="${element.id}">
-              <td style="text-align: center;">
-                <input type="checkbox" class="spell-toggle" id="{{_id}}" title="cast" {{checked data.cast}} />
-              </td>
-              <td>
-                <h4
-                  class="spell-name clickable"
-                  style="font-family: Souvenir-Medium; margin-bottom: 0px;"
-                  title="{{_id}}"
-                >{{name}}</h4>
-              </td>
-              <td style="text-align: center;">
-                <input type="checkbox" class="spell-toggle" id="{{_id}}" title="library" {{checked data.library}} />
-              </td>
-              <td style="text-align: center;">
-                <input type="checkbox" class="spell-toggle" id="{{_id}}" title="spellbook" {{checked data.spellbook}} />
-              </td>
-              <td style="text-align: center;">
-                <input type="checkbox" class="spell-toggle" id="{{_id}}" title="memorized" {{checked data.memorized}} />
-              </td>
-              <td style="text-align: center;">
-                <input type="checkbox" class="spell-toggle" id="{{_id}}" title="scroll" {{checked data.scroll}} />
-              </td>
-              <td style="text-align: center;">
-                <input type="checkbox" class="spell-toggle" id="{{_id}}" title="supplies" {{checked data.supplies}} />
-              </td>
-              <td style="text-align: center;">
-                <a class="item-control spell-delete" title="Delete Item" name="{{_id}}"><i class="fas fa-trash"></i></a>
-              </td>
-            </tr>
-          {{/each}}
-          <!-- Second Circle Spells -->
-          <tr>
-            <td
-              colspan="8"
-              style="text-align: center; background-color: rgba(0, 0, 0, 0.05); border-bottom: 1px solid gray;"
-            >~ Second Circle ~</td>
-          </tr>
-          {{#each data.computed.spells.second as |spell|}}
-            <tr id="${element.id}">
-              <td style="text-align: center;">
-                <input type="checkbox" class="spell-toggle" id="{{_id}}" title="cast" {{checked data.cast}} />
-              </td>
-              <td>
-                <h4
-                  class="spell-name clickable"
-                  style="font-family: Souvenir-Medium; margin-bottom: 0px;"
-                  title="{{_id}}"
-                >{{name}}</h4>
-              </td>
-              <td style="text-align: center;">
-                <input type="checkbox" class="spell-toggle" id="{{_id}}" title="library" {{checked data.library}} />
-              </td>
-              <td style="text-align: center;">
-                <input type="checkbox" class="spell-toggle" id="{{_id}}" title="spellbook" {{checked data.spellbook}} />
-              </td>
-              <td style="text-align: center;">
-                <input type="checkbox" class="spell-toggle" id="{{_id}}" title="memorized" {{checked data.memorized}} />
-              </td>
-              <td style="text-align: center;">
-                <input type="checkbox" class="spell-toggle" id="{{_id}}" title="scroll" {{checked data.scroll}} />
-              </td>
-              <td style="text-align: center;">
-                <input type="checkbox" class="spell-toggle" id="{{_id}}" title="supplies" {{checked data.supplies}} />
-              </td>
-              <td style="text-align: center;">
-                <a class="item-control spell-delete" title="Delete Item" name="{{_id}}"><i class="fas fa-trash"></i></a>
-              </td>
-            </tr>
+        <tbody>
+          {{#each data.computed.spellData as |spells|}}
+            {{> "systems/torchbearer/templates/parts/spell-list.html.hbs" circle=@key spells=spells}}
           {{/each}}
         </tbody>
       </table>

--- a/static/templates/parts/spell-list.html.hbs
+++ b/static/templates/parts/spell-list.html.hbs
@@ -10,27 +10,57 @@
 {{#each spells}}
   <tr class="spell-row" data-spell-id="{{_id}}">
     <td class="control">
-      <input type="checkbox" class="spell-toggle" title="cast" {{checked data.cast}} />
+      <input type="checkbox" class="spell-toggle" title="Cast?" {{checked data.cast}} />
     </td>
     <td>
-      <h4 class="spell-name clickable" title="{{_id}}">
+      <h4 class="spell-name clickable" title="{{data.name}}">
         {{data.name}}
       </h4>
     </td>
     <td class="control">
-      <input type="checkbox" class="spell-toggle" title="library" {{checked data.library}} />
+      <input
+        type="checkbox"
+        class="spell-toggle"
+        data-checkbox-type="library"
+        title="In library?"
+        {{checked data.library}}
+      />
     </td>
     <td class="control">
-      <input type="checkbox" class="spell-toggle" title="spellbook" {{checked data.spellbook}} />
+      <input
+        type="checkbox"
+        class="spell-toggle"
+        data-checkbox-type="spellbook"
+        title="In spellbook?"
+        {{checked data.spellbook}}
+      />
     </td>
     <td class="control">
-      <input type="checkbox" class="spell-toggle" title="memorized" {{checked data.memorized}} />
+      <input
+        type="checkbox"
+        class="spell-toggle"
+        data-checkbox-type="memorized"
+        title="Memorized?"
+        {{checked data.memorized}}
+      />
     </td>
     <td class="control">
-      <input type="checkbox" class="spell-toggle" title="scroll" {{checked data.scroll}} />
+      <input
+        type="checkbox"
+        class="spell-toggle"
+        data-checkbox-type="scroll"
+        title="Have scroll?"
+        {{checked data.scroll}}
+      />
     </td>
     <td class="control">
-      <input type="checkbox" class="spell-toggle" title="supplies" {{checked data.supplies}} />
+      <input
+        type="checkbox"
+        class="spell-toggle"
+        data-checkbox-type="supplies"
+        title="Have supplies?"
+        {{checked data.supplies}}
+      />
     </td>
     <td class="control">
       <a class="item-control spell-delete" title="Delete Spell">

--- a/static/templates/parts/spell-list.html.hbs
+++ b/static/templates/parts/spell-list.html.hbs
@@ -1,0 +1,41 @@
+<!-- {{circle}} Circle Spells -->
+<tr>
+  <td colspan="8" class="torchbearer spells spell-header">
+    ~
+    {{circle}}
+    Circle ~
+  </td>
+</tr>
+
+{{#each spells}}
+  <tr class="spell-row" data-spell-id="{{_id}}">
+    <td class="control">
+      <input type="checkbox" class="spell-toggle" title="cast" {{checked data.cast}} />
+    </td>
+    <td>
+      <h4 class="spell-name clickable" title="{{_id}}">
+        {{data.name}}
+      </h4>
+    </td>
+    <td class="control">
+      <input type="checkbox" class="spell-toggle" title="library" {{checked data.library}} />
+    </td>
+    <td class="control">
+      <input type="checkbox" class="spell-toggle" title="spellbook" {{checked data.spellbook}} />
+    </td>
+    <td class="control">
+      <input type="checkbox" class="spell-toggle" title="memorized" {{checked data.memorized}} />
+    </td>
+    <td class="control">
+      <input type="checkbox" class="spell-toggle" title="scroll" {{checked data.scroll}} />
+    </td>
+    <td class="control">
+      <input type="checkbox" class="spell-toggle" title="supplies" {{checked data.supplies}} />
+    </td>
+    <td class="control">
+      <a class="item-control spell-delete" title="Delete Spell">
+        <i class="fas fa-trash"></i>
+      </a>
+    </td>
+  </tr>
+{{/each}}


### PR DESCRIPTION
This PR simplifies the code, styling, and HTML around spell rendering, and supports all five circles.

### Discussion

@lupinelegend 

I've currently set it up so that sheets don't actually render spell circles that don't exist. This saves a bunch of empty rows since most characters won't have spells of most circles, but would we rather render all circles, even the empty ones?

### Screenshots

#### With two circles

![SpellCircles](https://user-images.githubusercontent.com/10442802/137244031-a219f1a9-3222-4dff-8cbc-ef7d881cdab8.PNG)

#### With just one circle

![OnlyOneCircle](https://user-images.githubusercontent.com/10442802/137244211-baca6808-286f-4ed8-96bd-567636c3fb6b.PNG)

#### With no circles at all

![NoSpells](https://user-images.githubusercontent.com/10442802/137244228-ef0ed802-7f4c-4cb1-ad32-ac560a6e7cf5.PNG)
